### PR TITLE
Change default max zoom to not have to deal with slow panning

### DIFF
--- a/BG3Cam/MainWindow.cs
+++ b/BG3Cam/MainWindow.cs
@@ -54,7 +54,7 @@ namespace BG3Cam
                 MessageBox.Show("Max Zoom not found", "Bad Game State");
                 Environment.Exit(0);
             }
-            maxZoomVal.Value = (decimal)100f;
+            maxZoomVal.Value = (decimal)17.5f;
             minZoomVal.Value = (decimal)0.5f;
             AddDefaultVal(obj + worldCamOffset + camMaxOffset + 4);
             AddDefaultVal(obj + battleCamOffset + camMaxOffset);


### PR DESCRIPTION
As title says, was testing the tool and it seems that the panning speed is connected to max zoom.
17.5 also feels like a good default to get decent zoom without being silly